### PR TITLE
Fix address panic

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,8 +221,10 @@ func validateKey(key string) error {
 
 func configPath(appName, configName string) (string, string, error) {
 	dir, err := os.UserHomeDir()
+
+	// If the HOME env var is not set (can happen if we’re called by a process other than a shell), we still try to construct a writable path
 	if err != nil {
-		return "", "", err
+		dir = os.TempDir()
 	}
 
 	dir = filepath.Join(dir, ".config", appName)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,6 +71,17 @@ func TestNewConfigPermissionDenied(t *testing.T) {
 	}
 }
 
+func TestNewConfigWithoutHomeEnv(t *testing.T) {
+	home := os.Getenv("HOME")
+	os.Unsetenv("HOME")
+	defer os.Setenv("HOME", home)
+
+	appName := uuid.New()
+
+	_, err := config.NewConfig(appName, "test")
+	assert.NoError(t, err)
+}
+
 func TestCreatesConfigFileLazily(t *testing.T) {
 	cfg, teardown := setupConfig(t, "")
 	defer teardown()


### PR DESCRIPTION
1. `os.UserHomeDir()` returns an error only when `$HOME` environment is not set. Therefore, instead of returning an error, the dir variable is set to a temporary directory (using the `os.TempDir()` function), this helps to avoid address panic in the future.

2. Added a test to check when environment `$HOME` is not set.
